### PR TITLE
globalConfirmModal 승인 후 중복처리되는 오류 수정

### DIFF
--- a/lib/framework/static/js/ff_global1.js
+++ b/lib/framework/static/js/ff_global1.js
@@ -710,6 +710,7 @@ function globalConfirmModal(title, body, func) {
   $("#confirm_body").html(body);
   //$('#confirm_button').attr('onclick', func);
   $("body").on('click', '#confirm_button', function(e){
+    e.stopImmediatePropagation();
     e.preventDefault();
     func();
   });


### PR DESCRIPTION
목록에서 아래와 같이 사용시 여러아이템을 삭제하는 경우 중복으로 function(remove_item)을 호출하는 문제 수정
```javascript
$("body").on('click', '#remove_rcpt_btn', function(e){
  e.preventDefault();
  item_id = $('#item_id').val();
  globalConfirmModal('아이템삭제', '아이템을 삭제하시겠습니까?', function() {
    remove_item(item_id);
  });   
});
```