### PR TITLE
support 패키지 로거 설정 수정

### DIFF
--- a/lib/framework/init_main.py
+++ b/lib/framework/init_main.py
@@ -66,6 +66,7 @@ class Framework:
         self.__make_default_dir()
         
         self.logger = self.get_logger(__package__)
+        self.get_logger('support')
         import support
 
         self.__prepare_starting()

--- a/lib/support/__init__.py
+++ b/lib/support/__init__.py
@@ -10,7 +10,9 @@ def d(data):
 
 from .logger import get_logger
 
-logger = get_logger()
+#logger = get_logger()
+import logging
+logger = logging.getLogger('support')
 
 from .base.aes import SupportAES
 from .base.discord import SupportDiscord


### PR DESCRIPTION
`lib/support/__init__.py` 에서 `get_logger()`를 호출할 때 `name`및 `log_path`를 명시하지 않아 `/usr/local/lib/python3.10/dist-packages/flaskfarm/main.log`에 support 패키지의 로그가 기록되는 현상이 있습니다.
'support' 이름으로 로거를 생성하고 framework가 초기화 될 때 'support' 로거의 핸들러를 설정하는 방식이 어떨까 싶어서 PR 남깁니다.