### PR TITLE
로그 출력시 HTML escape

### DIFF
--- a/lib/framework/static/js/ff_global1.js
+++ b/lib/framework/static/js/ff_global1.js
@@ -733,11 +733,18 @@ function logline(line) {
     str += '<span class="text-white" style="display:inline-block; width:100px; word-break:break-all;">' + tmps[3] + '</span>&nbsp;';
 
     str += '<span class="text-white" style="display:inline-block; width:150px; word-break:break-all;">' + tmps[4] + '</span>&nbsp;'
-    str += '<span class="' + color + '" style="display:inline-block; word-break:break-all;">' + tmps[5] + '</span>';
+    str += '<span class="' + color + '" style="display:inline-block; word-break:break-all;">' + htmlEncode(tmps[5]) + '</span>';
     
   } else {
-    str += '<span class="text-white">'+line+'</span>';
+    str += '<span class="text-white">'+htmlEncode(line)+'</span>';
   }
   str += '</li>';
   return str;
+}
+
+function htmlEncode(input) {
+  return input
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
 }


### PR DESCRIPTION
로그 내용에 자바스크립트나 html 태그가 있을 경우 로그 뷰 페이지에서 해당 내용이 렌더링 되는 경우가 있습니다.
로그 뷰 페이지에 로그를 출력할 때는 html 태그를 escape해야 할 것 같습니다.