### PR TITLE
X-Forwarded-Proto 헤더 참조(프록시 scheme과 실제 scheme이 다를 경우)

### DIFF
--- a/lib/framework/init_main.py
+++ b/lib/framework/init_main.py
@@ -16,6 +16,7 @@ from flask_login import LoginManager, login_required
 from flask_socketio import SocketIO
 from flask_sqlalchemy import SQLAlchemy
 from pytz import timezone, utc
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from .init_declare import CustomFormatter, check_api
 
@@ -71,6 +72,7 @@ class Framework:
 
         self.__prepare_starting()
         self.app = Flask(__name__)
+        self.app.wsgi_app = ProxyFix(self.app.wsgi_app, x_proto=1)
         self.__config_initialize('flask')
 
         self.__init_db()


### PR DESCRIPTION
flaskfarm에서 요청 url을 재사용하는 경우 scheme이 유지되도록 설정하는 패치입니다.
프록시 서버를 거쳐서 요청이 이뤄질 경우 실제 scheme이 유지되지 않는 경우가 있습니다.
그럴 경우 프록시 서버에서 X-Forwarded-Proto 헤더를 함께 보내줘야 하고 flask도 이를 참조하도록 설정해야 한다고 합니다.